### PR TITLE
Fix scrolling through image assets detail especially in iPad

### DIFF
--- a/NohanaImagePicker/Size.swift
+++ b/NohanaImagePicker/Size.swift
@@ -59,7 +59,7 @@ struct Size {
         return CGRect(
             x: 0,
             y: appBarHeight,
-            width: UIScreen.main.bounds.width,
-            height: UIScreen.main.bounds.height - appBarHeight - toolbarHeight)
+            width: viewController.view.bounds.width,
+            height: viewController.view.bounds.height - appBarHeight - toolbarHeight)
     }
 }


### PR DESCRIPTION
Hi,

I am using your `ImagePicker` at work but unfortunately Q&A guys filed a bug for the abnormal behaviour in iPad after iOS 13 update.

Hope that my fix make sense and which is not harming your initial thought.

Please accept my merge request.

Kind regards,
Goppinath

Fixes: https://github.com/nohana/NohanaImagePicker/issues/111