### PR TITLE
Fixed reload sections when selected photos.

### DIFF
--- a/NohanaImagePicker/AssetListSelectableDateSectionController.swift
+++ b/NohanaImagePicker/AssetListSelectableDateSectionController.swift
@@ -183,14 +183,14 @@ class AssetListSelectableDateSectionController: UICollectionViewController, UICo
                     let title = nohanaImagePickerController.config.strings.albumListTitle ?? NSLocalizedString("action.title.deselect", tableName: "NohanaImagePicker", bundle: nohanaImagePickerController.assetBundle, comment: "")
                     let deselect = UIAction(title: title, image: UIImage(systemName: "minus.circle"), attributes: [.destructive]) { _ in
                         nohanaImagePickerController.dropAsset(asset)
-                        collectionView.reloadItems(at: [indexPath])
+                        collectionView.reloadSections(IndexSet(integer: indexPath.section))
                     }
                     return UIMenu(title: "", children: [deselect])
                 } else {
                     let title = nohanaImagePickerController.config.strings.albumListTitle ?? NSLocalizedString("action.title.select", tableName: "NohanaImagePicker", bundle: nohanaImagePickerController.assetBundle, comment: "")
                     let select = UIAction(title: title, image: UIImage(systemName: "checkmark.circle")) { _ in
                         nohanaImagePickerController.pickAsset(asset)
-                        collectionView.reloadItems(at: [indexPath])
+                        collectionView.reloadSections(IndexSet(integer: indexPath.section))
                     }
                     return UIMenu(title: "", children: [select])
                 }


### PR DESCRIPTION
Fixed bug in "AssetListSelectableDateSectionController.
The check mark in the date header was not in the selected state.
Reload UICollectionView section when selecting or deselecting a photo from the ContextMenu.