### PR TITLE
Modify to initially display the specified album

### DIFF
--- a/Demo/DemoListViewController.swift
+++ b/Demo/DemoListViewController.swift
@@ -31,6 +31,7 @@ class DemoListViewController: UITableViewController, NohanaImagePickerController
         Cell(title: "Disable to pick assets", selector: #selector(DemoListViewController.showDisableToPickAssetsPicker)),
         Cell(title: "Custom UI", selector: #selector(DemoListViewController.showCustomUIPicker)),
         Cell(title: "Selectable Album Date Section", selector: #selector(DemoListViewController.showSelectableDateSectionPicker)),
+        Cell(title: "Specify the default album", selector: #selector(DemoListViewController.showSpecifyDefaultAlbumPicker)),
     ]
 
     override func viewDidAppear(_ animated: Bool) {
@@ -142,6 +143,38 @@ class DemoListViewController: UITableViewController, NohanaImagePickerController
     @objc func showSelectableDateSectionPicker() {
         let picker = NohanaImagePickerController()
         picker.canPickDateSection = true
+        picker.delegate = self
+        present(picker, animated: true, completion: nil)
+    }
+    
+    @objc func showSpecifyDefaultAlbumPicker() {
+        let subtypes: [PHAssetCollectionSubtype] = [
+            .albumRegular,
+            .albumSyncedEvent,
+            .albumSyncedFaces,
+            .albumSyncedAlbum,
+            .albumImported,
+            .albumMyPhotoStream,
+            .albumCloudShared,
+            .smartAlbumGeneric,
+            .smartAlbumFavorites,
+            .smartAlbumRecentlyAdded,
+            .smartAlbumUserLibrary
+        ]
+        var albumListFetchResult: [PHFetchResult<PHAssetCollection>] = []
+        let assetCollectionTypes: [PHAssetCollectionType] = [.smartAlbum, .album]
+        assetCollectionTypes.forEach {
+            albumListFetchResult += [PHAssetCollection.fetchAssetCollections(with: $0, subtype: .any, options: nil)]
+        }
+        var assetCollections: [PHAssetCollection] = []
+        albumListFetchResult.forEach {
+            $0.enumerateObjects { (assetCollection, _, _) in
+                if subtypes.contains(assetCollection.assetCollectionSubtype) {
+                    assetCollections.append(assetCollection)
+                }
+            }
+        }
+        let picker = NohanaImagePickerController(assetCollectionSubtypes: subtypes, mediaType: .photo, enableExpandingPhotoAnimation: false, defaultAssetCollection: assetCollections.last)
         picker.delegate = self
         present(picker, animated: true, completion: nil)
     }

--- a/NohanaImagePicker/NohanaImagePickerController.swift
+++ b/NohanaImagePicker/NohanaImagePickerController.swift
@@ -146,10 +146,10 @@ open class NohanaImagePickerController: UIViewController {
         addChild(navigationController)
         view.addSubview(navigationController.view)
         NSLayoutConstraint.activate([
-            navigationController.view.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-            navigationController.view.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
-            navigationController.view.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
-            navigationController.view.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            navigationController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            navigationController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
         navigationController.view.layoutIfNeeded()
         navigationController.didMove(toParent: self)

--- a/NohanaImagePicker/NohanaImagePickerController.swift
+++ b/NohanaImagePicker/NohanaImagePickerController.swift
@@ -68,6 +68,7 @@ open class NohanaImagePickerController: UIViewController {
     let mediaType: MediaType
     let enableExpandingPhotoAnimation: Bool
     let assetCollectionSubtypes: [PHAssetCollectionSubtype]
+    let defaultAssetCollection: PHAssetCollection?
 
     public init() {
         assetCollectionSubtypes = [
@@ -86,14 +87,16 @@ open class NohanaImagePickerController: UIViewController {
         mediaType = .photo
         pickedAssetList = PickedAssetList()
         enableExpandingPhotoAnimation = true
+        defaultAssetCollection = nil
         super.init(nibName: nil, bundle: nil)
         self.pickedAssetList.nohanaImagePickerController = self
     }
 
-    public init(assetCollectionSubtypes: [PHAssetCollectionSubtype], mediaType: MediaType, enableExpandingPhotoAnimation: Bool) {
+    public init(assetCollectionSubtypes: [PHAssetCollectionSubtype], mediaType: MediaType, enableExpandingPhotoAnimation: Bool, defaultAssetCollection: PHAssetCollection?) {
         self.assetCollectionSubtypes = assetCollectionSubtypes
         self.mediaType = mediaType
         self.enableExpandingPhotoAnimation = enableExpandingPhotoAnimation
+        self.defaultAssetCollection = defaultAssetCollection
         pickedAssetList = PickedAssetList()
         super.init(nibName: nil, bundle: nil)
         self.pickedAssetList.nohanaImagePickerController = self

--- a/NohanaImagePicker/NohanaImagePickerController.swift
+++ b/NohanaImagePicker/NohanaImagePickerController.swift
@@ -97,6 +97,11 @@ open class NohanaImagePickerController: UIViewController {
         self.mediaType = mediaType
         self.enableExpandingPhotoAnimation = enableExpandingPhotoAnimation
         self.defaultAssetCollection = defaultAssetCollection
+        if let assetCollection = self.defaultAssetCollection {
+            if !assetCollectionSubtypes.contains(assetCollection.assetCollectionSubtype) {
+                fatalError("defaultAssetCollection doesn't contain the specified PHAssetCollectionSubtype")
+            }
+        }
         pickedAssetList = PickedAssetList()
         super.init(nibName: nil, bundle: nil)
         self.pickedAssetList.nohanaImagePickerController = self

--- a/NohanaImagePicker/RootViewController.swift
+++ b/NohanaImagePicker/RootViewController.swift
@@ -178,6 +178,7 @@ class RootViewController: UIViewController {
         oldViewController?.view.removeFromSuperview()
         oldViewController?.removeFromParent()
         newViewController.didMove(toParent: self)
+        currentChildViewController = newViewController
     }
     
     private func transformAnimation() {

--- a/NohanaImagePicker/RootViewController.swift
+++ b/NohanaImagePicker/RootViewController.swift
@@ -15,6 +15,7 @@
  */
 
 import UIKit
+import Photos
 
 class RootViewController: UIViewController {
     
@@ -53,7 +54,11 @@ class RootViewController: UIViewController {
         // Notification
         addPickPhotoKitAssetNotificationObservers()
         
-        showRecentPhotos()
+        if let assetCollection = nohanaImagePickerController.defaultAssetCollection {
+            showPhotosFromDefaultAlbum(album: assetCollection)
+        } else {
+            showRecentPhotos()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -117,6 +122,12 @@ class RootViewController: UIViewController {
         present(navigationController, animated: true, completion: nil)
     }
     
+    private func showPhotosFromDefaultAlbum(album: PHAssetCollection) {
+        let album = PhotoKitAssetList(album: album, mediaType: nohanaImagePickerController.mediaType, ascending: !nohanaImagePickerController.canPickDateSection)
+        switchChildViewController(currentChildViewController, toViewController: fetchAssetListViewController(album: album))
+        updateTitle(title: album.title)
+    }
+    
     private func showRecentPhotos() {
         albumList = PhotoKitAlbumList(
             assetCollectionTypes: [.smartAlbum, .album],
@@ -128,7 +139,7 @@ class RootViewController: UIViewController {
                 guard let self = self else { return }
                 DispatchQueue.main.async {
                     let album = self.albumList[0]
-                    self.switchChildViewController(nil, toViewController: self.fetchAssetListViewController(album: album))
+                    self.switchChildViewController(self.currentChildViewController, toViewController: self.fetchAssetListViewController(album: album))
                     self.updateTitle(title: album.title)
                 }
             })


### PR DESCRIPTION
Modified the initial display of the image picker to show the photos in the specified album.
Updated the demo app.

In addition, the following two problems have been corrected.
- Fixed a warning about AutoLayout.
- Fixed an issue where the old ChildViewController was not released when switching albums.