### PR TITLE
Improve album list display

### DIFF
--- a/NohanaImagePicker.xcodeproj/project.pbxproj
+++ b/NohanaImagePicker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3569CAA91EC1918E000C41C0 /* NohanaImagePicker.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3569CAA61EC1918E000C41C0 /* NohanaImagePicker.xcassets */; };
+		6A0117BE27D6011500B868F9 /* Array+Ex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0117BD27D6011500B868F9 /* Array+Ex.swift */; };
 		6A434AE72775631C009526D3 /* UIViewController+Ex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A434AE62775631C009526D3 /* UIViewController+Ex.swift */; };
 		6A8047FF276C3D77000F3B28 /* AlbumList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6A8047FE276C3D77000F3B28 /* AlbumList.storyboard */; };
 		6A804801276C3E80000F3B28 /* Moment.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6A804800276C3E80000F3B28 /* Moment.storyboard */; };
@@ -89,6 +90,7 @@
 		23D1CD93207CEB1200F8115E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/NohanaImagePicker.strings; sourceTree = "<group>"; };
 		3569CAA61EC1918E000C41C0 /* NohanaImagePicker.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = NohanaImagePicker.xcassets; sourceTree = "<group>"; };
 		3590F1F51EC1A79400F32E06 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/NohanaImagePicker.strings; sourceTree = "<group>"; };
+		6A0117BD27D6011500B868F9 /* Array+Ex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Ex.swift"; sourceTree = "<group>"; };
 		6A434AE62775631C009526D3 /* UIViewController+Ex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Ex.swift"; sourceTree = "<group>"; };
 		6A8047FE276C3D77000F3B28 /* AlbumList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AlbumList.storyboard; sourceTree = "<group>"; };
 		6A804800276C3E80000F3B28 /* Moment.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Moment.storyboard; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 			children = (
 				6AD1607E2770B23D00A8B066 /* UIApplication+Ex.swift */,
 				6A434AE62775631C009526D3 /* UIViewController+Ex.swift */,
+				6A0117BD27D6011500B868F9 /* Array+Ex.swift */,
 			);
 			name = Extension;
 			sourceTree = "<group>";
@@ -465,6 +468,7 @@
 				6AD1607F2770B23D00A8B066 /* UIApplication+Ex.swift in Sources */,
 				F25C10C21C8ED9BF007453C3 /* MomentViewController.swift in Sources */,
 				F25C69881CA23A0A005935D6 /* MomentCell.swift in Sources */,
+				6A0117BE27D6011500B868F9 /* Array+Ex.swift in Sources */,
 				F2FE1F781C901D9400FDBE7B /* MomentSectionHeaderView.swift in Sources */,
 				F1A26CD12738E88700433E9F /* AssetDateSection.swift in Sources */,
 				F23554281C69D5DB00796DCA /* NohanaImagePickerController.swift in Sources */,

--- a/NohanaImagePicker/Array+Ex.swift
+++ b/NohanaImagePicker/Array+Ex.swift
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 nohana, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+extension Array {
+    func chunked(by chunkSize: Int) -> [[Element]] {
+        return stride(from: 0, to: self.count, by: chunkSize).map {
+            Array(self[$0..<Swift.min($0 + chunkSize, self.count)])
+        }
+    }
+}

--- a/NohanaImagePicker/PhotoKitAlbumList.swift
+++ b/NohanaImagePicker/PhotoKitAlbumList.swift
@@ -60,8 +60,9 @@ public class PhotoKitAlbumList: ItemList {
             for fetchResult in albumListFetchResult {
                 fetchResult.enumerateObjects({ (album, index, stop) in
                     if self.assetCollectionSubtypes.contains(album.assetCollectionSubtype) || isAssetCollectionSubtypeAny {
-                        if self.shouldShowEmptyAlbum || PHAsset.fetchAssets(in: album, options: PhotoKitAssetList.fetchOptions(self.mediaType)).count != 0 {
-                            tmpAlbumList.append(PhotoKitAssetList(album: album, mediaType: self.mediaType, ascending: self.ascending))
+                        let assets = PhotoKitAssetList(album: album, mediaType: self.mediaType, ascending: self.ascending)
+                        if self.shouldShowEmptyAlbum || assets.count > 0 {
+                            tmpAlbumList.append(assets)
                         }
                     }
                 })

--- a/NohanaImagePicker/PhotoKitAlbumList.swift
+++ b/NohanaImagePicker/PhotoKitAlbumList.swift
@@ -53,24 +53,20 @@ public class PhotoKitAlbumList: ItemList {
             for type in self.assetCollectionTypes {
                 albumListFetchResult = albumListFetchResult + [PHAssetCollection.fetchAssetCollections(with: type, subtype: .any, options: nil)]
             }
-
             self.albumList = []
-            var tmpAlbumList: [Item] = []
             let isAssetCollectionSubtypeAny = self.assetCollectionSubtypes.contains(.any)
             for fetchResult in albumListFetchResult {
-                fetchResult.enumerateObjects({ (album, index, stop) in
-                    if self.assetCollectionSubtypes.contains(album.assetCollectionSubtype) || isAssetCollectionSubtypeAny {
-                        let assets = PhotoKitAssetList(album: album, mediaType: self.mediaType, ascending: self.ascending)
-                        if self.shouldShowEmptyAlbum || assets.count > 0 {
-                            tmpAlbumList.append(assets)
+                Array(0..<fetchResult.count).chunked(by: 20).map({ IndexSet($0) }).forEach {
+                    fetchResult.enumerateObjects(at: $0, options: []) { (album, index, stop) in
+                        if self.assetCollectionSubtypes.contains(album.assetCollectionSubtype) || isAssetCollectionSubtypeAny {
+                            let assets = PhotoKitAssetList(album: album, mediaType: self.mediaType, ascending: self.ascending)
+                            if self.shouldShowEmptyAlbum || assets.count > 0 {
+                                self.albumList.append(assets)
+                            }
                         }
                     }
-                })
-            }
-            self.albumList = tmpAlbumList
-
-            if let handler = handler {
-                handler()
+                    handler?()
+                }
             }
         }
     }

--- a/NohanaImagePicker/RootViewController.swift
+++ b/NohanaImagePicker/RootViewController.swift
@@ -28,6 +28,26 @@ class RootViewController: UIViewController {
     }()
     private var currentChildViewController: UIViewController?
     private var albumList: PhotoKitAlbumList!
+    private lazy var albumListViewController: AlbumListViewController = {
+        let storyboard = UIStoryboard(name: "AlbumList", bundle: nohanaImagePickerController.assetBundle)
+        guard let albumListViewController = storyboard.instantiateInitialViewController(creator: { corder in
+            AlbumListViewController(coder: corder, nohanaImagePickerController: self.nohanaImagePickerController)
+        }) else {
+            fatalError("albumListViewController init failed.")
+        }
+        albumListViewController.photoKitAlbumList = PhotoKitAlbumList(assetCollectionTypes: [.smartAlbum, .album],
+                                                                      assetCollectionSubtypes: nohanaImagePickerController.assetCollectionSubtypes,
+                                                                      mediaType: nohanaImagePickerController.mediaType,
+                                                                      shouldShowEmptyAlbum: nohanaImagePickerController.shouldShowMoment,
+                                                                      ascending: !nohanaImagePickerController.canPickDateSection,
+                                                                      handler: { [weak albumListViewController] in
+            DispatchQueue.main.async {
+                albumListViewController?.isLoading = false
+                albumListViewController?.tableView.reloadData()
+            }
+        })
+        return albumListViewController
+    }()
     
     init?(coder: NSCoder, nohanaImagePickerController: NohanaImagePickerController) {
         self.nohanaImagePickerController = nohanaImagePickerController
@@ -94,25 +114,7 @@ class RootViewController: UIViewController {
     }
     
     private func showAlbumList() {
-        let storyboard = UIStoryboard(name: "AlbumList", bundle: nohanaImagePickerController.assetBundle)
-        guard let albumListViewController = storyboard.instantiateInitialViewController(creator: { corder in
-            AlbumListViewController(coder: corder, nohanaImagePickerController: self.nohanaImagePickerController)
-        }) else {
-            fatalError("albumListViewController init failed.")
-        }
         let navigationController = UINavigationController(rootViewController: albumListViewController)
-        
-        albumListViewController.photoKitAlbumList = PhotoKitAlbumList(assetCollectionTypes: [.smartAlbum, .album],
-                                                                      assetCollectionSubtypes: nohanaImagePickerController.assetCollectionSubtypes,
-                                                                      mediaType: nohanaImagePickerController.mediaType,
-                                                                      shouldShowEmptyAlbum: nohanaImagePickerController.shouldShowMoment,
-                                                                      ascending: !nohanaImagePickerController.canPickDateSection,
-                                                                      handler: { [weak albumListViewController] in
-            DispatchQueue.main.async {
-                albumListViewController?.isLoading = false
-                albumListViewController?.tableView.reloadData()
-            }
-        })
         albumListViewController.delegate = self
         navigationController.presentationController?.delegate = self
         let appearance = navigationBarAppearance(nohanaImagePickerController)

--- a/NohanaImagePicker/RootViewController.swift
+++ b/NohanaImagePicker/RootViewController.swift
@@ -130,8 +130,8 @@ class RootViewController: UIViewController {
     
     private func showRecentPhotos() {
         albumList = PhotoKitAlbumList(
-            assetCollectionTypes: [.smartAlbum, .album],
-            assetCollectionSubtypes: nohanaImagePickerController.assetCollectionSubtypes,
+            assetCollectionTypes: [.smartAlbum],
+            assetCollectionSubtypes: [.smartAlbumUserLibrary],
             mediaType: nohanaImagePickerController.mediaType,
             shouldShowEmptyAlbum: nohanaImagePickerController.shouldShowEmptyAlbum,
             ascending: !nohanaImagePickerController.canPickDateSection,


### PR DESCRIPTION
It takes time to display many photos and albums, so this has been improved.
- When displaying recent photos in the initial display, only "smartAlbumUserLibrary" is specified in "assetCollectionSubtypes".
- Created an instance of AlbumListViewControler only once.
- Instead of processing all the albums at once, I ended up processing 20 albums at a time.
