### PR TITLE
Added DoneBarButtonItem color.

### DIFF
--- a/NohanaImagePicker/AssetListSelectableDateSectionController.swift
+++ b/NohanaImagePicker/AssetListSelectableDateSectionController.swift
@@ -60,6 +60,7 @@ class AssetListSelectableDateSectionController: UICollectionViewController, UICo
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setToolbarTitle(nohanaImagePickerController)
+        updateDoneBarButtonColor()
         collectionView?.reloadData()
     }
 
@@ -71,6 +72,13 @@ class AssetListSelectableDateSectionController: UICollectionViewController, UICo
         DispatchQueue.main.async {
             self.collectionView?.scrollToItem(at: indexPath, at: .bottom, animated: false)
         }
+    }
+
+    private func updateDoneBarButtonColor() {
+        parent?.navigationItem.rightBarButtonItem?.setTitleTextAttributes([
+            .foregroundColor: nohanaImagePickerController.config.color.navigationBarDoneBarButtonItem,
+            .font: UIFont.systemFont(ofSize: 17, weight: .semibold)
+        ], for: .normal)
     }
 
     // MARK: - UICollectionViewDataSource
@@ -242,6 +250,7 @@ class AssetListSelectableDateSectionController: UICollectionViewController, UICo
 extension AssetListSelectableDateSectionController: AssetDateSectionHeaderViewDelegate {
     func didPushPickButton() {
         collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
+        updateDoneBarButtonColor()
     }
 }
 
@@ -263,5 +272,6 @@ extension AssetListSelectableDateSectionController: AssetCellDelegate {
                 }
             }
         }
+        updateDoneBarButtonColor()
     }
 }

--- a/NohanaImagePicker/NohanaImagePickerController.swift
+++ b/NohanaImagePicker/NohanaImagePickerController.swift
@@ -172,6 +172,7 @@ extension NohanaImagePickerController {
             public var separator: UIColor?
             public var navigationBarBackground: UIColor = .white
             public var navigationBarForeground: UIColor = .black
+            public var navigationBarDoneBarButtonItem: UIColor = .black
         }
         public var color = Color()
 

--- a/NohanaImagePicker/RootViewController.swift
+++ b/NohanaImagePicker/RootViewController.swift
@@ -88,7 +88,7 @@ class RootViewController: UIViewController {
         // FIXME: The settings of UIBarButtonItemAppearance may not be reflected.
         // Probably, this problem occurs when the settings are set to reflect the entire application.
         navigationItem.rightBarButtonItem?.setTitleTextAttributes([
-            .foregroundColor: nohanaImagePickerController.config.color.navigationBarForeground,
+            .foregroundColor: nohanaImagePickerController.config.color.navigationBarDoneBarButtonItem,
             .font: UIFont.systemFont(ofSize: 17, weight: .semibold)
         ], for: .normal)
     }


### PR DESCRIPTION
We added `NohanaImagePickerController.Config.Color.navigationBarDoneBarButtonItem`.
When `AssetListSelectableDateSectionController.didPushPickButton` is called, this color is reflected on the `UINavigationBar`.