### PR TITLE
Added a property to control hiding a `PhotoAuthorizationLimitedView`.

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -45,5 +45,7 @@
 	</array>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>To pick some photos.</string>
+	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
+	<true/>
 </dict>
 </plist>

--- a/NohanaImagePicker/AssetListSelectableDateSectionController.swift
+++ b/NohanaImagePicker/AssetListSelectableDateSectionController.swift
@@ -38,7 +38,11 @@ class AssetListSelectableDateSectionController: UICollectionViewController, UICo
         return CGSize(width: cellWidth, height: cellWidth)
     }
 
-    private var isHiddenMenu: Bool {
+    private lazy var isHiddenPhotoAuthorizationLimitedCell: Bool = {
+        guard !nohanaImagePickerController.isHiddenPhotoAuthorizationLimitedView else {
+            return true
+        }
+
         let status: PHAuthorizationStatus
         if #available(iOS 14, *) {
             status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
@@ -51,7 +55,7 @@ class AssetListSelectableDateSectionController: UICollectionViewController, UICo
         default:
             return true
         }
-    }
+    }()
     
     init?(coder: NSCoder, nohanaImagePickerController: NohanaImagePickerController, photoKitAssetList: PhotoKitAssetList) {
         self.nohanaImagePickerController = nohanaImagePickerController
@@ -128,7 +132,8 @@ class AssetListSelectableDateSectionController: UICollectionViewController, UICo
                 fatalError("failed to dequeueReusableCellWithIdentifier(\"PhotoAuthorizationLimitedCell\")")
             }
             cell.delegate = self
-            cell.isHiddenMenu(isHiddenMenu)
+            let isHidden = isHiddenPhotoAuthorizationLimitedCell
+            cell.isHiddenCell(isHidden)
             return cell
         }
 
@@ -183,7 +188,7 @@ class AssetListSelectableDateSectionController: UICollectionViewController, UICo
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if Section(rawValue: indexPath.section) == .photoAuthorizationLimited {
-            return CGSize(width: collectionView.frame.width, height: isHiddenMenu ? 1 : 217)
+            return CGSize(width: collectionView.frame.width, height: isHiddenPhotoAuthorizationLimitedCell ? 1 : 217)
         } else {
             return cellSize
         }

--- a/NohanaImagePicker/NohanaImagePickerController.swift
+++ b/NohanaImagePicker/NohanaImagePickerController.swift
@@ -59,6 +59,7 @@ open class NohanaImagePickerController: UIViewController {
             .font: UIFont.systemFont(ofSize: 17, weight: .semibold)
         ]
     }()
+    open var isHiddenPhotoAuthorizationLimitedView: Bool = false
     lazy var assetBundle: Bundle = {
         let bundle = Bundle(for: type(of: self))
         if let path = bundle.path(forResource: "NohanaImagePicker", ofType: "bundle") {

--- a/NohanaImagePicker/PhotoAuthorizationLimitedCell.swift
+++ b/NohanaImagePicker/PhotoAuthorizationLimitedCell.swift
@@ -59,7 +59,7 @@ class PhotoAuthorizationLimitedCell: UICollectionViewCell {
         delegate?.didSelectAuthorizeAllPhotoButton(self)
     }
 
-    func isHiddenMenu(_ isHidden: Bool) {
+    func isHiddenCell(_ isHidden: Bool) {
         containerView.isHidden = isHidden
     }
 }


### PR DESCRIPTION
**Fix note**
- Added a property to control hiding a `PhotoAuthorizationLimitedView`.
- Added `PHPhotoLibraryPreventAutomaticLimitedAccessAlert = YES` in a Demo's `info.plist` file to prevent showing alert every requesting authorization status to access photos.
