### PR TITLE
Improve iCloud photo fetch to avoid degraded images

### DIFF
--- a/NohanaImagePicker/PhotoKitAsset.swift
+++ b/NohanaImagePicker/PhotoKitAsset.swift
@@ -36,14 +36,21 @@ public class PhotoKitAsset: Asset {
     public func image(targetSize: CGSize, handler: @escaping (ImageData?) -> Void) {
         let option = PHImageRequestOptions()
         option.isNetworkAccessAllowed = true
+        option.deliveryMode = .highQualityFormat
 
         _ = PHImageManager.default().requestImage(
             for: self.asset,
             targetSize: targetSize,
             contentMode: .aspectFit,
             options: option ) { (image, info) -> Void in
-                guard let image = image else {
+                if let error = info?[PHImageErrorKey] as? NSError {
                     handler(nil)
+                    return
+                }
+                let isDegraded = (
+                    info?[PHImageResultIsDegradedKey] as? Bool
+                ) ?? false
+                guard !isDegraded, let image = image else {
                     return
                 }
                 handler(ImageData(image: image, info: info as Dictionary<NSObject, AnyObject>?))


### PR DESCRIPTION
Previously, degraded (low-resolution) images could be treated as final results,
which caused photos to appear blurry in the picker and prevented uploads in some cases.
This was especially noticeable with iCloud-only photos and shared albums.

Changes:
- Ignore degraded image results when fetching photos
- Wait for high-quality images before treating the fetch as successful
- Improve error handling for iCloud photo fetch failures (e.g. CloudPhotoLibraryErrorDomain 1006)